### PR TITLE
Create taskcat config and parameters for bamboo builds to consume

### DIFF
--- a/ci/bamboo/quickstart-jira-dc-ci.json
+++ b/ci/bamboo/quickstart-jira-dc-ci.json
@@ -1,0 +1,46 @@
+[
+    {
+        "ParameterKey": "AssociatePublicIpAddress",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_8]"
+    },
+    {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "$[taskcat_genpass_8]"
+    },
+    {
+        "ParameterKey": "DBStorage",
+        "ParameterValue": "100"
+    },
+    {
+        "ParameterKey": "DBStorageType",
+        "ParameterValue": "Provisioned IOPS"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "CustomDnsName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "TomcatScheme",
+        "ParameterValue": "https"
+    },
+    {
+        "ParameterKey": "SSLCertificateARN",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    }
+]

--- a/ci/bamboo/taskcat-ci.yml
+++ b/ci/bamboo/taskcat-ci.yml
@@ -1,0 +1,13 @@
+---
+global:
+  marketplace-ami: false
+  owner: dc-deployments-syd@atlassian.com
+  qsname: quickstart-atlassian-jira
+  regions:
+    - us-east-2
+  reporting: true
+
+tests:
+  jira:
+    parameter_input: bamboo/quickstart-jira-dc-ci.json
+    template_file: quickstart-jira-dc.template.yaml


### PR DESCRIPTION
DCD-232

Adds new set of taskcat parameters that will be used by internal builds. These parameters allow configuration of custom DNS and an SSL certificate. This new file is used so that test configuration changes can be made alongside template changes without affecting Amazon's builds which use a different configuration to our preference.