### PR TITLE
Rename AssociatePublicIP Parameter to be more accurate

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -493,7 +493,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC)
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   KeyPairName:
     Default: ''

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -36,8 +36,8 @@ Metadata:
         Parameters:
           - AccessCIDR
           - AvailabilityZones
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
@@ -93,8 +93,6 @@ Metadata:
     ParameterLabels:
       AccessCIDR:
         default: Trusted IP range
-      AssociatePublicIpAddress:
-        default: Assign public IP
       AvailabilityZones:
         default: Availability Zones
       CatalinaOpts:
@@ -159,6 +157,8 @@ Metadata:
         default: SSH keyname to use with the repository (Optional)
       HostedZone:
         default: Route 53 Hosted Zone (optional)
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       JiraProduct:
         default: Jira Product *
       JiraVersion:
@@ -210,12 +210,6 @@ Metadata:
 
 Parameters:
   # Jira DC template parameters
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   CatalinaOpts:
     Default: ''
     Description: Pass in any additional jvm options to tune Catalina
@@ -495,6 +489,12 @@ Parameters:
     Default: ''
     Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC)
+    Type: String
   KeyPairName:
     Default: ''
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
@@ -651,7 +651,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         CatalinaOpts: !Ref 'CatalinaOpts'
         CidrBlock: !Ref 'CidrBlock'
         ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -30,7 +30,7 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
+          - InternetFacingLoadBalancer
           - CidrBlock
           - KeyPairName
           - SSLCertificateARN
@@ -75,8 +75,6 @@ Metadata:
           - TomcatScheme
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       CatalinaOpts:
         default: Catalina options
       CidrBlock:
@@ -139,6 +137,8 @@ Metadata:
         default: SSH keyname to use with the repository (Optional)
       HostedZone:
         default: Route 53 Hosted Zone (optional)
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       JiraProduct:
         default: Jira Product *
       JiraVersion:
@@ -173,12 +173,6 @@ Metadata:
         default: Tomcat protocol Scheme
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   CatalinaOpts:
     Default: ''
     Description: Pass in any additional jvm options to tune Catalina
@@ -439,6 +433,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
     Description: The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC)
+    Type: String
   JiraProduct:
     Default: Software
     Description: The Jira product to install.
@@ -543,7 +543,7 @@ Conditions:
   UseHostedZone:
     !Not [!Equals [!Ref HostedZone, '']]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
 Mappings:
   AWSInstanceType2Arch:
     c4.xlarge:

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -437,7 +437,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC)
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   JiraProduct:
     Default: Software


### PR DESCRIPTION
Before this parameter said it made the EC2 instances publicly accessible which isn't true. It simply determines whether the load balancer is internet facing or internal. This is now more clear.