### PR TITLE
DCD-289: Fix linting

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+templates:
+  - templates/*

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1103,7 +1103,6 @@ Resources:
           Ebs:
             VolumeSize: !Ref ClusterNodeVolumeSize
         - DeviceName: /dev/xvdf
-          Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref JiraClusterNodeInstanceProfile


### PR DESCRIPTION
Only minor issue.

```
E2523 Only one of [VirtualName, Ebs, NoDevice] should be specified for Resources/ClusterNodeLaunchConfig/Properties/BlockDeviceMappings/1
templates/quickstart-jira-dc.template.yaml:1105:11
```

The Ebs empty definition is not required.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig-blockdev-mapping.html

Build result:
https://server-syd-bamboo.internal.atlassian.com/browse/ZDCD-AWSJIRA3-3
