### PR TITLE
DCD-652: Integrate with CloudWatch dashboard subtemplate

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -19,8 +19,13 @@ Metadata:
           - ClusterNodeInstanceType
           - ClusterNodeMax
           - ClusterNodeMin
-          - ClusterNodeVolumeSize
-      - Label:
+          - ClusterNodeVolumeSize 
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
+          - CloudWatchIntegration
+     - Label:
           default: Database
         Parameters:
           - DBEngine
@@ -50,14 +55,6 @@ Metadata:
         Parameters:
           - CustomDnsName
           - HostedZone
-      - Label:
-          default: Cluster Node Deployment Repository; this is used to install and configure the application.
-        Parameters:
-          - DeploymentAutomationRepository
-          - DeploymentAutomationBranch
-          - DeploymentAutomationPlaybook
-          - DeploymentAutomationKeyName
-          - CloudWatchIntegration
       - Label:
           default: Application Tuning (Optional) - dbref - https://confluence.atlassian.com/display/AdminJIRAServer/Tuning+database+connections tomcatref - http://tomcat.apache.org/tomcat-7.0-doc/config/http.html
         Parameters:

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -16,6 +16,11 @@ Metadata:
           - ClusterNodeMax
           - ClusterNodeMin
           - ClusterNodeVolumeSize
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
+          - CloudWatchIntegration
       - Label:
           default: Database
         Parameters:
@@ -40,14 +45,6 @@ Metadata:
         Parameters:
           - CustomDnsName
           - HostedZone
-      - Label:
-          default: Cluster Node Deployment Repository; this is used to install and configure the application.
-        Parameters:
-          - DeploymentAutomationRepository
-          - DeploymentAutomationBranch
-          - DeploymentAutomationPlaybook
-          - DeploymentAutomationKeyName
-          - CloudWatchIntegration
       - Label:
           default: Application Tuning (Optional) - dbref - https://confluence.atlassian.com/display/AdminJIRAServer/Tuning+database+connections tomcatref - http://tomcat.apache.org/tomcat-7.0-doc/config/http.html
         Parameters:

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1319,6 +1319,23 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}"
       TargetKeyId: !Ref EncryptionKey
+
+# Optional: Cloudwatch dashboard to be created when CloudWatch is enabled
+  CloudwatchDashboard:
+    DependsOn:
+      - DB
+    Condition: EnableCloudWatch
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-cloudwatch-dashboard.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      Parameters:
+        ProductStackName: !Sub "${AWS::StackName}"
+        ProductFamilyName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "name"]
+        AsgToMonitor: !Ref ClusterNodeGroup
+        DatabaseIdentifier: !Sub ["${DBStackNamePrefix}-db", {DBStackNamePrefix: !Ref 'AWS::StackName'}]
+
 Outputs:
   ServiceURL:
     Description: The URL to access this Atlassian service
@@ -1369,3 +1386,7 @@ Outputs:
     Export: {
       Name: !Join ['', [!Ref 'AWS::StackName', '-EFSCname']]
     }
+  CloudwatchDashboard:
+    Description: Cloudwatch monitoring dashboard URL
+    Value: !GetAtt CloudwatchDashboard.Outputs.Dashboard
+    Condition: EnableCloudWatch

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1318,7 +1318,7 @@ Resources:
       TargetKeyId: !Ref EncryptionKey
 
 # Optional: Cloudwatch dashboard to be created when CloudWatch is enabled
-  CloudwatchDashboard:
+  CloudWatchDashboard:
     DependsOn:
       - DB
     Condition: EnableCloudWatch
@@ -1383,7 +1383,7 @@ Outputs:
     Export: {
       Name: !Join ['', [!Ref 'AWS::StackName', '-EFSCname']]
     }
-  CloudwatchDashboard:
-    Description: Cloudwatch monitoring dashboard URL
-    Value: !GetAtt CloudwatchDashboard.Outputs.Dashboard
+  CloudWatchDashboardURL:
+    Description: CloudWatch monitoring dashboard URL
+    Value: !GetAtt CloudWatchDashboard.Outputs.Dashboard
     Condition: EnableCloudWatch


### PR DESCRIPTION
TO be merged after https://github.com/atlassian/quickstart-atlassian-jira/pull/26

Invokes dashboard template if EnableCloudwatch condition is met. Dashboard URL is displayed in the output section.

https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#dashboards:name=jiracw5-dashboard;expand=true is a running example of the dashboard

This PR will be ready for merge once the dependent atlassian-services sub template has been merged to upstream master & deployed