### PR TITLE
DCD-658: Ansible custom params

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -25,6 +25,7 @@ Metadata:
           - DeploymentAutomationBranch
           - DeploymentAutomationPlaybook
           - DeploymentAutomationKeyName
+          - DeploymentAutomationCustomParams
       - Label:
           default: Database
         Parameters:
@@ -152,7 +153,9 @@ Metadata:
       DeploymentAutomationPlaybook:
         default: The Ansible playbook to invoke to initialize the instance
       DeploymentAutomationKeyName:
-        default: SSH keyname to use with the repository
+        default: SSH keyname to use with the repository (Optional)
+      DeploymentAutomationCustomParams:
+        default: Custom command-line parameters for Ansible. (Optional)
       CloudWatchIntegration:
         default: Enable CloudWatch integration
       HostedZone:
@@ -477,7 +480,11 @@ Parameters:
   DeploymentAutomationPlaybook:
     Default: "aws_jira_dc_node.yml"
     Type: String
-    Description: The Ansible playbook to invoke to initialize the Jira node on first start.
+    Description: The Ansible playbook to invoke to initialise the Jira node on first start.
+  DeploymentAutomationCustomParams:
+    Default: ""
+    Type: String
+    Description: Additional command-line options for the `ansible-playbook` command. See the repository README for more details. (Optional)
   DeploymentAutomationKeyName:
     Default: ""
     Type: String
@@ -701,6 +708,7 @@ Resources:
         DeploymentAutomationBranch: !Ref 'DeploymentAutomationBranch'
         DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
         DeploymentAutomationPlaybook: !Ref 'DeploymentAutomationPlaybook'
+        DeploymentAutomationCustomParams: !Ref 'DeploymentAutomationCustomParams'
         CloudWatchIntegration: !Ref 'CloudWatchIntegration'
         HostedZone: !Ref 'HostedZone'
         JiraProduct: !Ref 'JiraProduct'

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -20,6 +20,7 @@ Metadata:
           - DeploymentAutomationRepository
           - DeploymentAutomationBranch
           - DeploymentAutomationPlaybook
+          - DeploymentAutomationCustomParams
           - DeploymentAutomationKeyName
       - Label:
           default: Database
@@ -135,7 +136,9 @@ Metadata:
       DeploymentAutomationPlaybook:
         default: The Ansible playbook to invoke to initialize the instance
       DeploymentAutomationKeyName:
-        default: SSH keyname to use with the repository
+        default: SSH keyname to use with the repository (Optional)
+      DeploymentAutomationCustomParams:
+        default: Custom command-line parameters for Ansible. (Optional)
       CloudWatchIntegration:
         default: Enable CloudWatch integration
       HostedZone:
@@ -451,6 +454,10 @@ Parameters:
     Default: "aws_jira_dc_node.yml"
     Type: String
     Description: The Ansible playbook to invoke to initialize the Jira node on first start.
+  DeploymentAutomationCustomParams:
+    Default: ""
+    Type: String
+    Description: Additional command-line options for the `ansible-playbook` command. See the repository README for more details. (Optional)
   DeploymentAutomationKeyName:
     Default: ""
     Type: String
@@ -1067,6 +1074,7 @@ Resources:
                     - !Sub ["ATL_DEPLOYMENT_REPOSITORY_BRANCH=${DeployRepositoryBranch}", DeployRepositoryBranch: !Ref "DeploymentAutomationBranch"]
                     - !Sub ["ATL_DEPLOYMENT_REPOSITORY_PLAYBOOK=${DeployRepositoryPlaybook}", DeployRepositoryPlaybook: !Ref "DeploymentAutomationPlaybook"]
                     - !Sub ["ATL_DEPLOYMENT_REPOSITORY_KEYNAME=${DeployRepositoryKeyName}", DeployRepositoryKeyName: !Ref "DeploymentAutomationKeyName"]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY_CUSTOM_PARAMS='${DeployRepositoryCustomParams}'", DeployRepositoryCustomParams: !Ref "DeploymentAutomationCustomParams"]
 
                     - !Sub ["ATL_AWS_ENABLE_CLOUDWATCH=${EnableCW}", EnableCW: !If [EnableCloudWatch, true, false]]
                     - !Sub ["ATL_AWS_ENABLE_CLOUDWATCH_LOGS=${EnableCWLogs}", EnableCWLogs: !If [EnableCloudWatchLogs, true, false]]


### PR DESCRIPTION
This adds the ability to supply custom parameters to the Ansible command-line. The main reason is to enable using `-e var=override` to customise deployments; a practical example of this is in the Ansible repo README.

This presented for discussion; there is more than one way to do this, but this is probably the most general and simplest to understand.