### PR TITLE
QUICK-265: Add default JVM options

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1020,6 +1020,7 @@ Resources:
                     - "ATL_DB_DRIVER=org.postgresql.Driver"
                     - "ATL_JDBC_DB_NAME=jira"
                     - "ATL_JDBC_USER=atljira"
+                    - "ATL_JVM_OPTS='-XX:+ExplicitGCInvokesConcurrent -XX:ReservedCodeCacheSize=512M'"
                     - "ATL_APP_DATA_MOUNT_ENABLED=false"
                     - "ATL_ENABLED_PRODUCTS=Jira"
                     - "ATL_ENABLED_SHARED_HOMES="


### PR DESCRIPTION
Paired with @bpar476 
Related to: https://bitbucket.org/atlassian/dc-deployments-automation/pull-requests/27/quick-265-add-jvm-opts-parameter-to-jira
Adds default JVM startup parameters