### PR TITLE
DCD-691: add arch mapping for c4.large EC2 instance type

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -602,6 +602,9 @@ Conditions:
     !Equals [!Ref DBEngine, "PostgreSQL"]
 Mappings:
   AWSInstanceType2Arch:
+    c4.large:
+      Arch: HVM64
+      Jvmheap: 5120m
     c4.xlarge:
       Arch: HVM64
       Jvmheap: 4608m

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -604,7 +604,7 @@ Mappings:
   AWSInstanceType2Arch:
     c4.large:
       Arch: HVM64
-      Jvmheap: 5120m
+      Jvmheap: 2304m
     c4.xlarge:
       Arch: HVM64
       Jvmheap: 4608m


### PR DESCRIPTION
Noticed this while deploying a test environment and trying to use a smaller instance type. PR for confluence incoming