### PR TITLE
Added group for S3bucket parameters

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -72,6 +72,11 @@ Metadata:
           - TomcatMinSpareThreads
           - TomcatProtocol
           - TomcatRedirectPort
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
 
     ParameterLabels:
       CatalinaOpts:
@@ -174,6 +179,10 @@ Metadata:
         default: Tomcat Protocol
       TomcatRedirectPort:
         default: Tomcat Redirect Port
+      QSS3BucketName:
+        default: Quick Start S3 Bucket Name
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
 
 Parameters:
   CatalinaOpts:


### PR DESCRIPTION
- Added the "AWS Quick Start configuration" ParameterGroup to the non-ASI template for Jira. 
- Added the QSS3BucketName and QSS3KeyPrefix parameters to it

The other non-ASI templates have this, but the Jira one doesn't.

https://bulldog.internal.atlassian.com/browse/DCD-700