### PR TITLE
DCD-889: Add version tagging and ASG tag permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ downstream repository that is not actively supported.
 We welcome pull requests, issues, and comments in the **[upstream repository](https://bitbucket.org/atlassian/atlassian-aws-deployment/src/master/quickstarts/)**.
 
 If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/). 
+
+## Development notes
+
+### Pre-commit hook
+
+It is recommended that you install the hooks under `submodules/quickstart-atlassian-services/scripts/hooks/`; this will
+ensure that the metadata tags in the templates are automatically updated on
+commit. The simplest method of doing this is:
+
+    git config --add core.hooksPath submodules/quickstart-atlassian-services/scripts/hooks/
+
+Alternatively you can invoke
+`submodules/quickstart-atlassian-services/scripts/hooks/update-tags.py`
+manually.

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -517,7 +517,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: 8.5.0
+    Default: 8.5.3
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -968,6 +968,7 @@ Resources:
                   - 'autoscaling:CreateOrUpdateTags'
                   - 'ec2:CreateTags'
                   - 'ec2:DescribeInstances'
+                  - 'ec2:DescribeTags'
                   - 'route53:ListHostedZones'
                   - 'route53:ListResourceRecordSet'
                 Effect: Allow

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1004,6 +1004,13 @@ Resources:
         - Key: Cluster
           Value: !Ref AWS::StackName
           PropagateAtLaunch: true
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          PropagateAtLaunch: true
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
+          PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -1168,6 +1175,11 @@ Resources:
           Value: !Join [' ', [!Ref 'AWS::StackName', 'cluster shared-files']]
         - Key: Application
           Value: !Ref AWS::StackId
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1250,6 +1262,12 @@ Resources:
           Value: !Sub ["${StackName}-LoadBalancer", StackName: !Ref 'AWS::StackName']
         - Key: Cluster
           Value: !Ref AWS::StackName
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
+
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -1308,6 +1326,11 @@ Resources:
           Value: MainTargetGroup
         - Key: Cluster
           Value: !Ref AWS::StackName
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1373,6 +1396,11 @@ Resources:
       Tags:
         - Key: Name
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1402,6 +1430,11 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
+        # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
+        - Key: "atl:quickstart:commit-id"
+          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+        - Key: "atl:quickstart:timestamp"
+          Value: "TIMESTAMP: 20200108:22.26"
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1008,10 +1008,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1179,9 +1179,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1266,9 +1266,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
 
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -1330,9 +1330,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1400,9 +1400,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1434,9 +1434,9 @@ Resources:
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: da3b13803bf12bc77c4ea41800eb274f1da528b4"
+          Value: "COMMIT: 2cc65ee943783c6abb39826f645f230ae0fdf3cb"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 20200108:22.26"
+          Value: "TIMESTAMP: 20200115:22.36"
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -505,7 +505,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: 8.5.0
+    Default: 8.5.3
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -964,6 +964,8 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Action:
+                  - 'autoscaling:DescribeTags'
+                  - 'autoscaling:CreateOrUpdateTags'
                   - 'ec2:DescribeInstances'
                   - 'route53:ListHostedZones'
                   - 'route53:ListResourceRecordSet'

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -966,6 +966,7 @@ Resources:
               - Action:
                   - 'autoscaling:DescribeTags'
                   - 'autoscaling:CreateOrUpdateTags'
+                  - 'ec2:CreateTags'
                   - 'ec2:DescribeInstances'
                   - 'route53:ListHostedZones'
                   - 'route53:ListResourceRecordSet'


### PR DESCRIPTION
This adds commit & timestamp tagging to the Jira QS, and grants the nodes the ability to manipulate the ASG tags to persist run-time metadata.