### PR TITLE
DCD-954: Add bastion to security group

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1362,7 +1362,7 @@ Resources:
             !Sub
               - "${BastionIp}/32"
               - BastionIp:
-                  Fn::ImportValue: !Sub '${ExportPrefix}BastionIp'
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1356,6 +1356,14 @@ Resources:
           ToPort: 22
           CidrIp: !Ref CidrBlock
         - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp:
+            !Sub
+              - "${BastionIp}/32"
+              - BastionIp:
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionIp'
+        - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp: !Ref CidrBlock


### PR DESCRIPTION
Imports the private IP of the bastion host from the ASI so that when `CidrBlock` is set the Bastion can still SSH to the webserver.

See [This PR](https://github.com/atlassian/quickstart-atlassian-services/pull/31) for more context.