### PR TITLE
CHET-298: Allow users to select the Postgres engine

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -30,8 +30,7 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
-          - DBPostgresEngineVersion
-          - DBAuroraPostgresEngineVersion
+          - DBEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -116,10 +115,8 @@ Metadata:
         default: Existing DNS name
       DBEngine:
         default: The database engine to deploy with
-      DBPostgresEngineVersion:
-        default: The PosgreSQL engine version to use
-      DBAuroraPostgresEngineVersion:
-        default: The Aurora PosgreSQL engine version to use
+      DBEngineVersion:
+        default: The database engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -355,20 +352,13 @@ Parameters:
       - 'Amazon Aurora PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
-  DBPostgresEngineVersion:
+  DBEngineVersion:
     Default: 9.6
     AllowedValues:
       - 9.6
       - 10
       - 11
-    Description: "Select the PostgreSQL engine version to use"
-    Type: String
-  DBAuroraPostgresEngineVersion:
-    Default: 9.6.12
-    AllowedValues:
-      - 9.6.12
-      - 11.4
-    Description: "Select the Aurora PostgreSQL engine version to use"
+    Description: "Select the engine version to use"
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -699,6 +689,19 @@ Conditions:
   ProvisionBastion: !And
     - !Equals [!Ref BastionHostRequired, true]
     - !Condition KeyProvided
+  DBEnginePostgres:
+    !Equals [!Ref DBEngine, "PostgreSQL"]
+      
+Mappings:
+  SemanticDBVersions:
+    PostgreSQL:
+      9.6: 9.6
+      10: 10
+      11: 11
+    AuroraPostgreSQL:
+      9.6: 9.6.12
+      10: 10.5
+      11: 11.4      
 
 Resources:
   VPCStack:
@@ -741,8 +744,10 @@ Resources:
         ClusterNodeVolumeSize: !Ref 'ClusterNodeVolumeSize'
         CustomDnsName: !Ref 'CustomDnsName'
         DBEngine: !Ref DBEngine
-        DBPostgresEngineVersion: !Ref DBPostgresEngineVersion
-        DBAuroraPostgresEngineVersion: !Ref DBAuroraPostgresEngineVersion
+        DBEngineVersion: !If
+          - DBEnginePostgres
+          - !FindInMap [SemanticDBVersions, PostgreSQL, !Ref DBEngineVersion]
+          - !FindInMap [SemanticDBVersions, AuroraPostgreSQL, !Ref DBEngineVersion]
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -66,7 +66,6 @@ Metadata:
         Parameters:
             - TomcatContextPath
             - CatalinaOpts
-            - JvmHeapOverride
             - DBPoolMaxSize
             - DBPoolMinSize
             - DBMaxIdle
@@ -175,8 +174,6 @@ Metadata:
         default: Jira Product *
       JiraVersion:
         default: Version *
-      JvmHeapOverride:
-        default: JVM Heap Size Override
       BastionHostRequired:
           default: Deploy Bastion host
       KeyPairName:
@@ -353,9 +350,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9.6
+    Default: 9
     AllowedValues:
-      - 9.6
+      - 9
       - 10
       - 11
     Description: "Select the engine version to use"
@@ -548,10 +545,6 @@ Parameters:
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
     Type: String
-  JvmHeapOverride:
-    Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
-    Type: String
   InternetFacingLoadBalancer:
     Default: "true"
     AllowedValues: ["true", "false"]
@@ -689,19 +682,6 @@ Conditions:
   ProvisionBastion: !And
     - !Equals [!Ref BastionHostRequired, true]
     - !Condition KeyProvided
-  DBEnginePostgres:
-    !Equals [!Ref DBEngine, "PostgreSQL"]
-      
-Mappings:
-  SemanticDBVersions:
-    PostgreSQL:
-      9.6: 9.6
-      10: 10
-      11: 11
-    AuroraPostgreSQL:
-      9.6: 9.6.12
-      10: 10.5
-      11: 11.4      
 
 Resources:
   VPCStack:
@@ -744,10 +724,7 @@ Resources:
         ClusterNodeVolumeSize: !Ref 'ClusterNodeVolumeSize'
         CustomDnsName: !Ref 'CustomDnsName'
         DBEngine: !Ref DBEngine
-        DBEngineVersion: !If
-          - DBEnginePostgres
-          - !FindInMap [SemanticDBVersions, PostgreSQL, !Ref DBEngineVersion]
-          - !FindInMap [SemanticDBVersions, AuroraPostgreSQL, !Ref DBEngineVersion]
+        DBEngineVersion: !Ref DBEngineVersion
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'
@@ -777,7 +754,6 @@ Resources:
         InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         JiraProduct: !Ref 'JiraProduct'
         JiraVersion: !Ref 'JiraVersion'
-        JvmHeapOverride: !Ref 'JvmHeapOverride'
         KeyPairName: !Ref 'KeyPairName'
         MailEnabled: !Ref 'MailEnabled'
         QSS3BucketName: !Ref 'QSS3BucketName'

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -30,6 +30,8 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
+          - DBPostgresEngineVersion
+          - DBAuroraPostgresEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -114,6 +116,10 @@ Metadata:
         default: Existing DNS name
       DBEngine:
         default: The database engine to deploy with
+      DBPostgresEngineVersion:
+        default: The PosgreSQL engine version to use
+      DBAuroraPostgresEngineVersion:
+        default: The Aurora PosgreSQL engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -348,6 +354,21 @@ Parameters:
       - 'PostgreSQL'
       - 'Amazon Aurora PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
+  DBPostgresEngineVersion:
+    Default: 9.6
+    AllowedValues:
+      - 9.6
+      - 10
+      - 11
+    Description: "Select the PostgreSQL engine version to use"
+    Type: String
+  DBAuroraPostgresEngineVersion:
+    Default: 9.6.12
+    AllowedValues:
+      - 9.6.12
+      - 11.4
+    Description: "Select the Aurora PostgreSQL engine version to use"
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -720,6 +741,8 @@ Resources:
         ClusterNodeVolumeSize: !Ref 'ClusterNodeVolumeSize'
         CustomDnsName: !Ref 'CustomDnsName'
         DBEngine: !Ref DBEngine
+        DBPostgresEngineVersion: !Ref DBPostgresEngineVersion
+        DBAuroraPostgresEngineVersion: !Ref DBAuroraPostgresEngineVersion
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -66,6 +66,7 @@ Metadata:
         Parameters:
             - TomcatContextPath
             - CatalinaOpts
+            - JvmHeapOverride
             - DBPoolMaxSize
             - DBPoolMinSize
             - DBMaxIdle
@@ -79,7 +80,6 @@ Metadata:
             - DBTimeBetweenEvictionRunsMillis
             - MailEnabled
             - TomcatAcceptCount
-            - TomcatConnectionTimeout
             - TomcatDefaultConnectorPort
             - TomcatEnableLookups
             - TomcatMaxThreads
@@ -174,6 +174,8 @@ Metadata:
         default: Jira Product *
       JiraVersion:
         default: Version *
+      JvmHeapOverride:
+        default: JVM Heap Size Override
       BastionHostRequired:
           default: Deploy Bastion host
       KeyPairName:
@@ -192,8 +194,6 @@ Metadata:
         default: SSL Certificate ARN
       TomcatAcceptCount:
         default: Tomcat Accept Count
-      TomcatConnectionTimeout:
-        default: Tomcat Connection Timeout
       TomcatContextPath:
         default: Tomcat Context Path
       TomcatDefaultConnectorPort:
@@ -545,6 +545,10 @@ Parameters:
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
     Type: String
+  JvmHeapOverride:
+    Default: ''
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
   InternetFacingLoadBalancer:
     Default: "true"
     AllowedValues: ["true", "false"]
@@ -580,10 +584,6 @@ Parameters:
   TomcatAcceptCount:
     Default: 10
     Description: The maximum queue length for incoming connection requests when all possible request processing threads are in use
-    Type: Number
-  TomcatConnectionTimeout:
-    Default: 20000
-    Description: The number of milliseconds this Connector will wait, after accepting a connection, for the request URI line to be presented
     Type: Number
   TomcatContextPath:
     Default: ''
@@ -754,13 +754,13 @@ Resources:
         InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         JiraProduct: !Ref 'JiraProduct'
         JiraVersion: !Ref 'JiraVersion'
+        JvmHeapOverride: !Ref 'JvmHeapOverride'
         KeyPairName: !Ref 'KeyPairName'
         MailEnabled: !Ref 'MailEnabled'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
         SSLCertificateARN: !Ref 'SSLCertificateARN'
         TomcatAcceptCount: !Ref 'TomcatAcceptCount'
-        TomcatConnectionTimeout: !Ref 'TomcatConnectionTimeout'
         TomcatContextPath: !Ref 'TomcatContextPath'
         TomcatDefaultConnectorPort: !Ref 'TomcatDefaultConnectorPort'
         TomcatEnableLookups: !Ref 'TomcatEnableLookups'

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -355,7 +355,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "Select the engine version to use"
+    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -350,9 +350,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9.6
+    Default: 9
     AllowedValues:
-      - 9.6
+      - 9
       - 10
       - 11
     Description: "Select the engine version to use"

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -350,9 +350,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 9.6
     AllowedValues:
-      - 9
+      - 9.6
       - 10
       - 11
     Description: "Select the engine version to use"

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -56,6 +56,7 @@ Metadata:
         Parameters:
           - TomcatContextPath
           - CatalinaOpts
+          - JvmHeapOverride
           - DBPoolMaxSize
           - DBPoolMinSize
           - DBMaxIdle
@@ -162,6 +163,8 @@ Metadata:
         default: Jira Product *
       JiraVersion:
         default: Version *
+      JvmHeapOverride:
+        default: JVM Heap Size Override
       BastionHostRequired:
         default: Use Bastion host
       KeyPairName:
@@ -533,6 +536,10 @@ Parameters:
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
     Type: String
+  JvmHeapOverride:
+    Default: ''
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
   BastionHostRequired:
     Default: "true"
     AllowedValues:
@@ -630,6 +637,8 @@ Conditions:
     !Not [!Equals [!Ref SSLCertificateARN, '']]
   KeyProvided:
     !Not [!Equals [!Ref KeyPairName, '']]
+  OverrideHeap:
+    !Not [!Equals [!Ref JvmHeapOverride, '']]
   UseContextPath:
     !Not [!Equals [!Ref TomcatContextPath, '']]
   UseCustomDnsName:
@@ -1111,6 +1120,7 @@ Resources:
                     - !Sub ["ATL_JIRA_FULL_DISPLAY_NAME=${JiraFullDisplayName}", JiraFullDisplayName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "fulldisplayname"]]
                     - !Sub ["ATL_JIRA_NAME=${JiraProductName}", JiraProductName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "name"]]
                     - !Sub ["ATL_JIRA_SHORT_DISPLAY_NAME=${JiraShortDisplayName}", JiraShortDisplayName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "shortdisplayname"]]
+                    - !Sub ["ATL_JVM_HEAP=${AtlJvmHeap}", AtlJvmHeap: !If [OverrideHeap, !Ref 'JvmHeapOverride', !FindInMap [AWSInstanceType2Arch, !Ref ClusterNodeInstanceType, Jvmheap]]]
                     - !Sub ["ATL_PROXY_NAME=${AtlProxyName}", AtlProxyName: !If [UseCustomDnsName, !Ref CustomDnsName, !If [UseHostedZone, !Ref LoadBalancerCname, !GetAtt LoadBalancer.DNSName]]]
                     - !Sub ["ATL_TOMCAT_ACCEPTCOUNT=${TomcatAcceptCount}", TomcatAcceptCount: !Ref TomcatAcceptCount]
                     - !Sub ["ATL_TOMCAT_CONNECTIONTIMEOUT=${TomcatConnectionTimeout}", TomcatConnectionTimeout: !Ref TomcatConnectionTimeout]

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -335,9 +335,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9.6
+    Default: 9
     AllowedValues:
-      - 9.6
+      - 9
       - 10
       - 11
     Description: "Select the engine version to use"

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -26,8 +26,7 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
-          - DBPostgresEngineVersion
-          - DBAuroraPostgresEngineVersion
+          - DBEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -104,10 +103,8 @@ Metadata:
         default: Existing DNS name
       DBEngine:
         default: The database engine to deploy with
-      DBPostgresEngineVersion:
-        default: The PosgreSQL engine version to use
-      DBAuroraPostgresEngineVersion:
-        default: The Aurora PosgreSQL engine version to use
+      DBEngineVersion:
+        default: The database engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -337,20 +334,13 @@ Parameters:
       - 'Amazon Aurora PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
-  DBPostgresEngineVersion:
+  DBEngineVersion:
     Default: 9.6
     AllowedValues:
       - 9.6
       - 10
       - 11
-    Description: "Select the PostgreSQL engine version to use"
-    Type: String
-  DBAuroraPostgresEngineVersion:
-    Default: 9.6.12
-    AllowedValues:
-      - 9.6.12
-      - 11.4
-    Description: "Select the Aurora PostgreSQL engine version to use"
+    Description: "Select the engine version to use"
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -978,6 +968,16 @@ Mappings:
       HVM64: ami-e9a9d388
     us-gov-east-1:
       HVM64: ami-a2d938d3
+      
+  SemanticDBVersions:
+    PostgreSQL:
+      9.6: 9.6
+      10: 10
+      11: 11
+    AuroraPostgreSQL:
+      9.6: 9.6.12
+      10: 10.5
+      11: 11.4
 
   JIRAProduct2NameAndVersion:
     Core:
@@ -1295,8 +1295,10 @@ Resources:
         - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         DatabaseImplementation: !Ref DBEngine
-        DBAuroraPostgresEngineVersion: !Ref DBAuroraPostgresEngineVersion
-        DBPostgresEngineVersion: !Ref DBPostgresEngineVersion
+        DBEngineVersion: !If
+          - DBEnginePostgres
+          - !FindInMap [SemanticDBVersions, PostgreSQL, !Ref DBEngineVersion]
+          - !FindInMap [SemanticDBVersions, AuroraPostgreSQL, !Ref DBEngineVersion]
         DBSecurityGroup: !Ref SecurityGroup
         DBAutoMinorVersionUpgrade: "true"
         DBBackupRetentionPeriod: "1"

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -26,6 +26,8 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
+          - DBPostgresEngineVersion
+          - DBAuroraPostgresEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -102,6 +104,10 @@ Metadata:
         default: Existing DNS name
       DBEngine:
         default: The database engine to deploy with
+      DBPostgresEngineVersion:
+        default: The PosgreSQL engine version to use
+      DBAuroraPostgresEngineVersion:
+        default: The Aurora PosgreSQL engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -330,6 +336,21 @@ Parameters:
       - 'PostgreSQL'
       - 'Amazon Aurora PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
+  DBPostgresEngineVersion:
+    Default: 9.6
+    AllowedValues:
+      - 9.6
+      - 10
+      - 11
+    Description: "Select the PostgreSQL engine version to use"
+    Type: String
+  DBAuroraPostgresEngineVersion:
+    Default: 9.6.12
+    AllowedValues:
+      - 9.6.12
+      - 11.4
+    Description: "Select the Aurora PostgreSQL engine version to use"
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -1274,6 +1295,8 @@ Resources:
         - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         DatabaseImplementation: !Ref DBEngine
+        DBAuroraPostgresEngineVersion: !Ref DBAuroraPostgresEngineVersion
+        DBPostgresEngineVersion: !Ref DBPostgresEngineVersion
         DBSecurityGroup: !Ref SecurityGroup
         DBAutoMinorVersionUpgrade: "true"
         DBBackupRetentionPeriod: "1"

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -340,7 +340,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "Select the engine version to use"
+    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -335,9 +335,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 9.6
     AllowedValues:
-      - 9
+      - 9.6
       - 10
       - 11
     Description: "Select the engine version to use"

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -56,7 +56,6 @@ Metadata:
         Parameters:
           - TomcatContextPath
           - CatalinaOpts
-          - JvmHeapOverride
           - DBPoolMaxSize
           - DBPoolMinSize
           - DBMaxIdle
@@ -163,8 +162,6 @@ Metadata:
         default: Jira Product *
       JiraVersion:
         default: Version *
-      JvmHeapOverride:
-        default: JVM Heap Size Override
       BastionHostRequired:
         default: Use Bastion host
       KeyPairName:
@@ -335,9 +332,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9.6
+    Default: 9
     AllowedValues:
-      - 9.6
+      - 9
       - 10
       - 11
     Description: "Select the engine version to use"
@@ -536,10 +533,6 @@ Parameters:
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
     Type: String
-  JvmHeapOverride:
-    Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
-    Type: String
   BastionHostRequired:
     Default: "true"
     AllowedValues:
@@ -637,8 +630,6 @@ Conditions:
     !Not [!Equals [!Ref SSLCertificateARN, '']]
   KeyProvided:
     !Not [!Equals [!Ref KeyPairName, '']]
-  OverrideHeap:
-    !Not [!Equals [!Ref JvmHeapOverride, '']]
   UseContextPath:
     !Not [!Equals [!Ref TomcatContextPath, '']]
   UseCustomDnsName:
@@ -968,16 +959,6 @@ Mappings:
       HVM64: ami-e9a9d388
     us-gov-east-1:
       HVM64: ami-a2d938d3
-      
-  SemanticDBVersions:
-    PostgreSQL:
-      9.6: 9.6
-      10: 10
-      11: 11
-    AuroraPostgreSQL:
-      9.6: 9.6.12
-      10: 10.5
-      11: 11.4
 
   JIRAProduct2NameAndVersion:
     Core:
@@ -1130,7 +1111,6 @@ Resources:
                     - !Sub ["ATL_JIRA_FULL_DISPLAY_NAME=${JiraFullDisplayName}", JiraFullDisplayName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "fulldisplayname"]]
                     - !Sub ["ATL_JIRA_NAME=${JiraProductName}", JiraProductName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "name"]]
                     - !Sub ["ATL_JIRA_SHORT_DISPLAY_NAME=${JiraShortDisplayName}", JiraShortDisplayName: !FindInMap [ "JIRAProduct2NameAndVersion", !Ref JiraProduct, "shortdisplayname"]]
-                    - !Sub ["ATL_JVM_HEAP=${AtlJvmHeap}", AtlJvmHeap: !If [OverrideHeap, !Ref 'JvmHeapOverride', !FindInMap [AWSInstanceType2Arch, !Ref ClusterNodeInstanceType, Jvmheap]]]
                     - !Sub ["ATL_PROXY_NAME=${AtlProxyName}", AtlProxyName: !If [UseCustomDnsName, !Ref CustomDnsName, !If [UseHostedZone, !Ref LoadBalancerCname, !GetAtt LoadBalancer.DNSName]]]
                     - !Sub ["ATL_TOMCAT_ACCEPTCOUNT=${TomcatAcceptCount}", TomcatAcceptCount: !Ref TomcatAcceptCount]
                     - !Sub ["ATL_TOMCAT_CONNECTIONTIMEOUT=${TomcatConnectionTimeout}", TomcatConnectionTimeout: !Ref TomcatConnectionTimeout]
@@ -1295,10 +1275,7 @@ Resources:
         - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         DatabaseImplementation: !Ref DBEngine
-        DBEngineVersion: !If
-          - DBEnginePostgres
-          - !FindInMap [SemanticDBVersions, PostgreSQL, !Ref DBEngineVersion]
-          - !FindInMap [SemanticDBVersions, AuroraPostgreSQL, !Ref DBEngineVersion]
+        DBEngineVersion: !Ref DBEngineVersion
         DBSecurityGroup: !Ref SecurityGroup
         DBAutoMinorVersionUpgrade: "true"
         DBBackupRetentionPeriod: "1"


### PR DESCRIPTION
As this is a custom template change specifically for Trebuchet we have removed the `TomcatConnectionTimeout` within `quickstart-jira-dc-with-vpc.template.yaml`  so that we do not exceed the 60 parameter limit. This value is defaulted to `20000` in `quickstart-jira-dc.template.yaml`

For this version selection change to be added to the public QS templates a piece of work will probably need to be undertaken to deprecate and strip out a lot of these custom parameters where the can be injected via ansible instead.

Associated `quickstart-atlassian-services` PR here:
https://github.com/atlassian/quickstart-atlassian-services/pull/36
