### PR TITLE
CHET-298: Update default Jira version to 8.9.1

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -540,7 +540,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.8.1"
+    Default: "8.9.1"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -355,7 +355,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -540,7 +540,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.9.1"
+    Default: "8.5.3"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -540,7 +540,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.5.3"
+    Default: "8.8.1"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -340,7 +340,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "The database engine version to use. We'll install a supported minor version that's suitable for your chosen engine"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:
     Default: db.m5.large
@@ -531,7 +531,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.9.1"
+    Default: "8.5.3"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -531,7 +531,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.5.3"
+    Default: "8.8.1"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -531,7 +531,7 @@ Parameters:
       - Software
       - ServiceDesk
   JiraVersion:
-    Default: "8.8.1"
+    Default: "8.9.1"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.1.0 for Jira Software, or 4.1.0 for ServiceDesk.
     Description: The version of Jira Software or Jira Service Desk to install. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Desk), or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).


### PR DESCRIPTION
Although still functional, I noticed when digging around in Jira, that the default version we install - `8.5.3` - complains about not fully supporting the DB versions [recently added to the templates](https://github.com/atlassian/quickstart-atlassian-services/pull/36/files), see below:

<img width="654" alt="image" src="https://user-images.githubusercontent.com/409063/84994433-07a5cc00-b18e-11ea-8ac8-4554f80564a4.png">

I've re-tested all of these DB versions (9, 10, 11) on Postgres and Aurora for version `8.8.1` of Jira and we get a supported result, see below.

Although testing was done with `8.8.1` this PR is recommending we upgrade the default version to `8.9.1` which is currently the latest version of Jira: https://confluence.atlassian.com/jirasoftware/jira-software-release-notes-776821069.html and which will [obviously support the same DB versions](https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html) as `8.8.1`

<img width="487" alt="image" src="https://user-images.githubusercontent.com/409063/84994619-489de080-b18e-11ea-953e-69e37eb36189.png">
