### PR TITLE
DCD-1434: Removed version 9 from DBEngineVersion

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -356,7 +356,6 @@ Parameters:
     AllowedValues:
       - 11
       - 10
-      - 9
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -356,7 +356,8 @@ Parameters:
     AllowedValues:
       - 11
       - 10
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
+      - 9
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -357,7 +357,7 @@ Parameters:
       - 11
       - 10
       - 9
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -342,7 +342,7 @@ Parameters:
       - 11
       - 10
       - 9
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -341,7 +341,8 @@ Parameters:
     AllowedValues:
       - 11
       - 10
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
+      - 9
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -341,7 +341,6 @@ Parameters:
     AllowedValues:
       - 11
       - 10
-      - 9
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:


### PR DESCRIPTION
Remove Postgres version 9 as the version will be EOL