### PR TITLE
DCD-1211 Update Postgresql version used in AWS QS due to 9.6 EOL

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -352,8 +352,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 11
+    Default: 12
     AllowedValues:
+      - 12
       - 11
       - 10
       - 9

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -337,8 +337,9 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 11
+    Default: 12
     AllowedValues:
+      - 12
       - 11
       - 10
       - 9


### PR DESCRIPTION
DCD-1211 Updated Postgresql version used in AWS QS due to 9.6 EOL